### PR TITLE
Add explosion animation: burst ring and flying orb particles

### DIFF
--- a/src/components/grid/Grid.css
+++ b/src/components/grid/Grid.css
@@ -5,6 +5,7 @@
   padding: 10px;
   max-width: 400px;
   margin: auto;
+  overflow: visible;
 }
 
 .grid-loading {
@@ -24,6 +25,7 @@
   border-radius: 8px;
   cursor: pointer;
   position: relative;
+  overflow: visible;
 }
 
 .grid-cell.disabled {
@@ -39,20 +41,96 @@
   font-weight: bold;
   line-height: 30px;
   color: white;
+  position: relative;
+  z-index: 1;
 }
 
-.orb.P0 {
-  background-color: red;
+.orb.P0 { background-color: red; }
+.orb.P1 { background-color: blue; }
+.orb.P2 { background-color: green; }
+.orb.P3 { background-color: #ffd740; }
+
+/* ── Explosion overlay ───────────────────────────────────── */
+.cell-burst {
+  position: absolute;
+  inset: 0;
+  overflow: visible;
+  pointer-events: none;
+  z-index: 10;
 }
 
-.orb.P1 {
-  background-color: blue;
+/* Expanding ring that radiates out from the exploding cell */
+.burst-ring {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 36px;
+  height: 36px;
+  margin-top: -18px;
+  margin-left: -18px;
+  border-radius: 50%;
+  border: 3px solid;
+  animation: burst-ring 0.44s ease-out forwards;
 }
 
-.orb.P2 {
-  background-color: green;
+@keyframes burst-ring {
+  0%   { transform: scale(0.6); opacity: 0.9; }
+  60%  { transform: scale(1.8); opacity: 0.5; }
+  100% { transform: scale(2.2); opacity: 0; }
 }
 
-.orb.P3 {
-  background-color: yellow;
+/* Orb particles that fly toward each neighbor */
+.flying-orb {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  animation-duration: 0.38s;
+  animation-timing-function: ease-in;
+  animation-fill-mode: forwards;
+}
+
+/* 55px = cell (50px) + gap (5px) */
+.flying-orb-up    { animation-name: fly-up; }
+.flying-orb-down  { animation-name: fly-down; }
+.flying-orb-left  { animation-name: fly-left; }
+.flying-orb-right { animation-name: fly-right; }
+
+@keyframes fly-up {
+  0%   { transform: translate(-50%, -50%) scale(1); opacity: 1; }
+  100% { transform: translate(-50%, calc(-50% - 55px)) scale(0.6); opacity: 0; }
+}
+
+@keyframes fly-down {
+  0%   { transform: translate(-50%, -50%) scale(1); opacity: 1; }
+  100% { transform: translate(-50%, calc(-50% + 55px)) scale(0.6); opacity: 0; }
+}
+
+@keyframes fly-left {
+  0%   { transform: translate(-50%, -50%) scale(1); opacity: 1; }
+  100% { transform: translate(calc(-50% - 55px), -50%) scale(0.6); opacity: 0; }
+}
+
+@keyframes fly-right {
+  0%   { transform: translate(-50%, -50%) scale(1); opacity: 1; }
+  100% { transform: translate(calc(-50% + 55px), -50%) scale(0.6); opacity: 0; }
+}
+
+/* Brief glow on cells receiving orbs */
+.cell-receive-glow {
+  position: absolute;
+  inset: 0;
+  border-radius: 6px;
+  pointer-events: none;
+  animation: receive-pulse 0.36s ease-out forwards;
+  z-index: 5;
+}
+
+@keyframes receive-pulse {
+  0%   { background: rgba(255, 255, 255, 0.35); }
+  60%  { background: rgba(255, 255, 255, 0.15); }
+  100% { background: rgba(255, 255, 255, 0); }
 }

--- a/src/components/grid/Grid.tsx
+++ b/src/components/grid/Grid.tsx
@@ -1,26 +1,85 @@
 import { motion } from "framer-motion";
-import React from "react";
+import React, { useEffect, useState } from "react";
 
 import "./Grid.css";
 
-const ChainReactionGrid = ({
+const ORB_COLORS: Record<string, string> = {
+  P0: "red",
+  P1: "blue",
+  P2: "green",
+  P3: "#ffd740",
+};
+
+const GRID_SIZE = 6;
+
+function validDirs(r: number, c: number): string[] {
+  const dirs: string[] = [];
+  if (r > 0)              dirs.push("up");
+  if (r < GRID_SIZE - 1)  dirs.push("down");
+  if (c > 0)              dirs.push("left");
+  if (c < GRID_SIZE - 1)  dirs.push("right");
+  return dirs;
+}
+
+function neighborOf(r: number, c: number, dir: string): [number, number] {
+  if (dir === "up")    return [r - 1, c];
+  if (dir === "down")  return [r + 1, c];
+  if (dir === "left")  return [r,     c - 1];
+  return                      [r,     c + 1];
+}
+
+interface Cell {
+  count: number;
+  player: string | null;
+  capacity: number;
+}
+
+interface Props {
+  grid: Cell[][] | null;
+  myPlayer: string | null;
+  isMyTurn: boolean;
+  gameOver: boolean;
+  handleCellClick: (row: number, col: number) => void;
+  explodedAt?: [number, number, string] | null;
+}
+
+const ChainReactionGrid: React.FC<Props> = ({
   grid,
   myPlayer,
   isMyTurn,
   gameOver,
   handleCellClick,
+  explodedAt,
 }) => {
+  const [burstKey, setBurstKey] = useState(0);
+
+  useEffect(() => {
+    if (explodedAt) {
+      setBurstKey((k) => k + 1);
+    }
+  }, [explodedAt]);
+
   if (!grid) {
     return <div className="grid-loading">Waiting for game state…</div>;
+  }
+
+  const [burstR, burstC, burstPlayer] = explodedAt ?? [-1, -1, ""];
+  const receivingCells = new Set<string>();
+  if (explodedAt) {
+    for (const dir of validDirs(burstR, burstC)) {
+      const [nr, nc] = neighborOf(burstR, burstC, dir);
+      receivingCells.add(`${nr}-${nc}`);
+    }
   }
 
   return (
     <div className="grid-container">
       {grid.map((row, rowIndex) =>
         row.map((cell, colIndex) => {
-          const isOpponentCell =
-            cell.player !== null && cell.player !== myPlayer;
+          const isOpponentCell = cell.player !== null && cell.player !== myPlayer;
           const disabled = gameOver || !isMyTurn || isOpponentCell;
+          const isBurst = explodedAt && rowIndex === burstR && colIndex === burstC;
+          const isReceiving = receivingCells.has(`${rowIndex}-${colIndex}`);
 
           return (
             <motion.div
@@ -31,11 +90,34 @@ const ChainReactionGrid = ({
             >
               {cell.count > 0 && (
                 <motion.div
+                  key={`orb-${rowIndex}-${colIndex}-${cell.count}-${cell.player}`}
                   className={`orb ${cell.player}`}
-                  animate={{ scale: 1.2 }}
+                  initial={{ scale: 0.5, opacity: 0.6 }}
+                  animate={{ scale: 1, opacity: 1 }}
+                  transition={{ type: "spring", stiffness: 400, damping: 20 }}
                 >
                   {cell.count}
                 </motion.div>
+              )}
+
+              {isBurst && (
+                <div key={`burst-${burstKey}`} className="cell-burst">
+                  <div
+                    className="burst-ring"
+                    style={{ borderColor: ORB_COLORS[burstPlayer] ?? "#fff" }}
+                  />
+                  {validDirs(burstR, burstC).map((dir) => (
+                    <div
+                      key={dir}
+                      className={`flying-orb flying-orb-${dir}`}
+                      style={{ background: ORB_COLORS[burstPlayer] ?? "#fff" }}
+                    />
+                  ))}
+                </div>
+              )}
+
+              {isReceiving && (
+                <div className="cell-receive-glow" />
               )}
             </motion.div>
           );


### PR DESCRIPTION
- When a cell explodes, a burst ring expands from it and orb particles fly out toward each neighbor in the valid directions (up/down/left/right per position)
- Receiving neighbor cells flash a brief white glow
- burstKey state increments on each new explodedAt event so React remounts the burst overlay even when the same cell explodes consecutively
- Orb elements use a composite key (count + player) so framer-motion plays a spring pop-in animation whenever the count or owner changes